### PR TITLE
Fix: Restore first page content (typewriter, images)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,14 @@
 "use client"
 import dynamic from 'next/dynamic'
-import { Suspense, memo } from 'react'
+import { Suspense } from 'react'
+import { CharacterShowcase } from "@/components/character-showcase"
+import { CharacterInfo } from "@/components/character-info"
 import { LanguageSwitcher } from "@/components/language-switcher"
-import { ThemeToggle } from "@/components/theme-toggle"
 import { Providers } from "@/components/providers"
+import { ScrollHandler } from "@/components/scroll-handler"
+import { ThemeToggle } from "@/components/theme-toggle"
+import { AuthorInfo } from "@/components/author-info"
+import { MapEntryButton } from "@/components/map-entry-button"
 
 // Dynamically import heavy components for better performance
 const PhotoGallery = dynamic(
@@ -21,33 +26,10 @@ const BackToTopButton = dynamic(
   { ssr: false }
 )
 
-// Memoize components to prevent unnecessary re-renders
-const CharacterShowcase = memo(
-  () => import('@/components/character-showcase').then(mod => mod.CharacterShowcase)
-)
-
-const CharacterInfo = dynamic(
-  () => import('@/components/character-info').then(mod => mod.CharacterInfo)
-)
-
-const AuthorInfo = dynamic(
-  () => import('@/components/author-info').then(mod => mod.AuthorInfo)
-)
-
-const MapEntryButton = dynamic(
-  () => import('@/components/map-entry-button').then(mod => mod.MapEntryButton)
-)
-
-const ScrollHandler = dynamic(
-  () => import('@/components/scroll-handler').then(mod => mod.ScrollHandler)
-)
-
 export default function Home() {
   return <Providers>
-    <Suspense fallback={null}>
-      <ScrollHandler />
-      <DynamicBackground />
-    </Suspense>
+    <ScrollHandler />
+    <DynamicBackground />
 
     <main className="min-h-screen">
       {/* Fixed Top Bar */}
@@ -60,23 +42,15 @@ export default function Home() {
       <div className="pt-20 pb-12 md:pt-24 md:pb-16">
         {/* Character Showcase - Reference shiro.page style */}
         <div className="max-w-7xl mx-auto px-4 md:px-8 mb-8 md:mb-16">
-          <Suspense fallback={<div className="h-[600px] animate-pulse bg-slate-100/50 dark:bg-slate-900/50 rounded-lg"></div>}>
-            <CharacterShowcase />
-          </Suspense>
+          <CharacterShowcase />
         </div>
 
         {/* Info Section - Two column layout */}
         <div className="max-w-7xl mx-auto px-4 md:px-8 grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-16 mb-8 md:mb-16">
-          <Suspense fallback={<div className="h-64 animate-pulse bg-slate-100/50 dark:bg-slate-900/50 rounded-lg"></div>}>
-            <CharacterInfo />
-          </Suspense>
+          <CharacterInfo />
           <div className="space-y-6 md:space-y-8">
-            <Suspense fallback={<div className="h-32 animate-pulse bg-slate-100/50 dark:bg-slate-900/50 rounded-lg"></div>}>
-              <AuthorInfo />
-            </Suspense>
-            <Suspense fallback={<div className="h-24 animate-pulse bg-slate-100/50 dark:bg-slate-900/50 rounded-lg"></div>}>
-              <MapEntryButton />
-            </Suspense>
+            <AuthorInfo />
+            <MapEntryButton />
           </div>
         </div>
 
@@ -88,9 +62,7 @@ export default function Home() {
         </div>
       </div>
 
-      <Suspense fallback={null}>
-        <BackToTopButton />
-      </Suspense>
+      <BackToTopButton />
     </main>
   </Providers>
 }


### PR DESCRIPTION
Issue: Performance optimization accidentally removed critical components
- CharacterShowcase with typewriter effect was incorrectly using memo/dynamic import
- CharacterInfo, AuthorInfo, MapEntryButton were also incorrectly optimized

Fix:
- Restore direct imports for critical above-fold components
- Keep dynamic imports only for truly heavy components:
  - PhotoGallery (many images)
  - DynamicBackground (mouse tracking)
  - BackToTopButton (below-fold)
- Remove unnecessary Suspense boundaries for immediate-render components
- Keep ScrollHandler as direct import

Restored content:
✅ Astricia name with typewriter effect
✅ Subtitle "一段命运的旅程" with i18n
✅ Character image with casual/winter switcher
✅ All character info and traits
✅ Author information
✅ Map entry button

Performance balance:
- Above-fold content: Direct imports for instant render
- Below-fold content: Dynamic imports for code splitting
- Optimal LCP and FCP scores

Build: ✅ Successful
All content now displays correctly on first page load.

